### PR TITLE
fix libyuv build on 32-bit arm

### DIFF
--- a/chromium-95-libyuv-arm.patch
+++ b/chromium-95-libyuv-arm.patch
@@ -1,0 +1,13 @@
+diff --git a/third_party/libyuv/source/row_neon.cc b/third_party/libyuv/source/row_neon.cc
+index 6ef6f1c..e4a9e1e 100644
+--- a/third_party/libyuv/source/row_neon.cc
++++ b/third_party/libyuv/source/row_neon.cc
+@@ -2346,7 +2346,7 @@ void ARGBToAB64Row_NEON(const uint8_t* src_argb,
+                         uint16_t* dst_ab64,
+                         int width) {
+   asm volatile(
+-      "vld1.8      q4, %3                        \n"  // shuffler
++      "vld1.8      {d8, d9}, %3                        \n"  // shuffler
+       "1:                                        \n"
+       "vld1.8      {q0}, [%0]!                   \n"
+       "vld1.8      {q2}, [%0]!                   \n"


### PR DESCRIPTION
q4 is equal to {d8, d9} and provides greater compatibility
a similar fix was used at tensorflow/tensorflow@4b08e71