### PR TITLE
Rebase chromium-96-compiler.patch to chromium 97.0.4692.8

### DIFF
--- a/chromium-96-compiler.patch
+++ b/chromium-96-compiler.patch
@@ -11,7 +11,7 @@ diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
 index 673716f..3ff820e 100644
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -292,8 +292,6 @@ config("compiler") {
+@@ -296,8 +296,6 @@ config("compiler") {
  
    configs += [
      # See the definitions below.
@@ -20,11 +20,11 @@ index 673716f..3ff820e 100644
      ":compiler_codegen",
      ":compiler_deterministic",
    ]
-@@ -532,24 +530,6 @@ config("compiler") {
+@@ -539,24 +537,6 @@ config("compiler") {
      ldflags += [ "-Wl,-z,keep-text-section-prefix" ]
    }
  
--  if (is_clang && !is_nacl && !use_xcode_clang) {
+-  if (is_clang && !is_nacl && !use_xcode_clang && current_os != "zos") {
 -    cflags += [ "-fcrash-diagnostics-dir=" + clang_diagnostic_dir ]
 -
 -    # TODO(hans): Remove this once Clang generates better optimized debug info
@@ -45,7 +45,7 @@ index 673716f..3ff820e 100644
    # C11/C++11 compiler flags setup.
    # ---------------------------
    if (is_linux || is_chromeos || is_android || (is_nacl && is_clang) ||
-@@ -1240,45 +1220,6 @@ config("compiler_deterministic") {
+@@ -1247,45 +1227,6 @@ config("compiler_deterministic") {
      }
    }
  
@@ -91,7 +91,7 @@ index 673716f..3ff820e 100644
    # Tells the compiler not to use absolute paths when passing the default
    # paths to the tools it invokes. We don't want this because we don't
    # really need it and it can mess up the goma cache entries.
-@@ -1698,7 +1639,7 @@ config("chromium_code") {
+@@ -1563,7 +1504,7 @@ config("chromium_code") {
        defines = [ "_HAS_NODISCARD" ]
      }
    } else {
@@ -100,7 +100,7 @@ index 673716f..3ff820e 100644
      if (treat_warnings_as_errors) {
        cflags += [ "-Werror" ]
  
-@@ -1707,10 +1648,6 @@ config("chromium_code") {
+@@ -1572,10 +1513,6 @@ config("chromium_code") {
        # well.
        ldflags = [ "-Werror" ]
      }
@@ -111,7 +111,7 @@ index 673716f..3ff820e 100644
  
      # In Chromium code, we define __STDC_foo_MACROS in order to get the
      # C99 macros on Mac and Linux.
-@@ -1719,15 +1656,6 @@ config("chromium_code") {
+@@ -1584,15 +1521,6 @@ config("chromium_code") {
        "__STDC_FORMAT_MACROS",
      ]
  
@@ -127,7 +127,7 @@ index 673716f..3ff820e 100644
      if (is_mac) {
        cflags_objc = [ "-Wobjc-missing-property-synthesis" ]
        cflags_objcc = [ "-Wobjc-missing-property-synthesis" ]
-@@ -2095,7 +2023,8 @@ config("default_stack_frames") {
+@@ -1960,7 +1888,8 @@ config("default_stack_frames") {
  }
  
  # Default "optimization on" config.
@@ -137,7 +137,7 @@ index 673716f..3ff820e 100644
    if (is_win) {
      if (chrome_pgo_phase != 2) {
        # Favor size over speed, /O1 must be before the common flags.
-@@ -2135,7 +2064,8 @@ config("optimize") {
+@@ -2000,7 +1929,8 @@ config("optimize") {
  }
  
  # Turn off optimizations.
@@ -147,7 +147,7 @@ index 673716f..3ff820e 100644
    if (is_win) {
      cflags = [
        "/Od",  # Disable optimization.
-@@ -2175,7 +2105,8 @@ config("no_optimize") {
+@@ -2040,7 +1970,8 @@ config("no_optimize") {
  # Turns up the optimization level. On Windows, this implies whole program
  # optimization and link-time code generation which is very expensive and should
  # be used sparingly.
@@ -157,7 +157,7 @@ index 673716f..3ff820e 100644
    if (is_nacl && is_nacl_irt) {
      # The NaCl IRT is a special case and always wants its own config.
      # Various components do:
-@@ -2208,7 +2139,8 @@ config("optimize_max") {
+@@ -2073,7 +2004,8 @@ config("optimize_max") {
  #
  # TODO(crbug.com/621335) - rework how all of these configs are related
  # so that we don't need this disclaimer.
@@ -167,7 +167,7 @@ index 673716f..3ff820e 100644
    if (is_nacl && is_nacl_irt) {
      # The NaCl IRT is a special case and always wants its own config.
      # Various components do:
-@@ -2234,7 +2166,8 @@ config("optimize_speed") {
+@@ -2099,7 +2031,8 @@ config("optimize_speed") {
    }
  }
  
@@ -177,7 +177,7 @@ index 673716f..3ff820e 100644
    cflags = [ "-O1" ] + common_optimize_on_cflags
    rustflags = [ "-Copt-level=1" ]
    ldflags = common_optimize_on_ldflags
-@@ -2354,7 +2287,8 @@ config("win_pdbaltpath") {
+@@ -2219,7 +2152,8 @@ config("win_pdbaltpath") {
  }
  
  # Full symbols.
@@ -187,7 +187,7 @@ index 673716f..3ff820e 100644
    if (is_win) {
      if (is_clang) {
        cflags = [ "/Z7" ]  # Debug information in the .obj files.
-@@ -2468,7 +2402,8 @@ config("symbols") {
+@@ -2338,7 +2272,8 @@ config("symbols") {
  # Minimal symbols.
  # This config guarantees to hold symbol for stack trace which are shown to user
  # when crash happens in unittests running on buildbot.
@@ -197,7 +197,7 @@ index 673716f..3ff820e 100644
    if (is_win) {
      # Functions, files, and line tables only.
      cflags = []
-@@ -2540,7 +2475,8 @@ config("minimal_symbols") {
+@@ -2408,7 +2343,8 @@ config("minimal_symbols") {
  # This configuration contains function names only. That is, the compiler is
  # told to not generate debug information and the linker then just puts function
  # names in the final debug information.


### PR DESCRIPTION
chromium-96-compiler.patch is still needed, but doesn't apply anymore, on chromium 97.0.4692.8.